### PR TITLE
Implement SFApiQuery.setBody( ArrayList<?> sfoDataObjectsFeed)

### DIFF
--- a/ShareFileJavaSDK/src/com/citrix/sharefile/api/SFApiQuery.java
+++ b/ShareFileJavaSDK/src/com/citrix/sharefile/api/SFApiQuery.java
@@ -593,7 +593,7 @@ public class SFApiQuery<T extends SFODataObject> implements ISFQuery<T>
 	@Override
 	public ISFQuery<T>  setBody( ArrayList<?> sfoDataObjectsFeed)
 	{
-		mBody = SFDefaultGsonParser.serialize(sfoDataObjectsFeed.getClass(), sfoDataObjectsFeed);
+        mBody = SFDefaultGsonParser.serialize(sfoDataObjectsFeed.getClass(), sfoDataObjectsFeed);
         return this;
 	}
 

--- a/ShareFileJavaSDK/src/com/citrix/sharefile/api/SFApiQuery.java
+++ b/ShareFileJavaSDK/src/com/citrix/sharefile/api/SFApiQuery.java
@@ -593,7 +593,7 @@ public class SFApiQuery<T extends SFODataObject> implements ISFQuery<T>
 	@Override
 	public ISFQuery<T>  setBody( ArrayList<?> sfoDataObjectsFeed)
 	{
-        Logger.e(TAG,"This is not implemented");
+		mBody = SFDefaultGsonParser.serialize(sfoDataObjectsFeed.getClass(), sfoDataObjectsFeed);
         return this;
 	}
 


### PR DESCRIPTION
This method, used for POSTing array payloads was not implemented in the SDK.  Adding an implementation.