### PR TITLE
Retrieve Shared Folders for a Specific User

### DIFF
--- a/ShareFileJavaSDK/src/com/citrix/sharefile/api/entities/SFUsersEntity.java
+++ b/ShareFileJavaSDK/src/com/citrix/sharefile/api/entities/SFUsersEntity.java
@@ -1430,6 +1430,24 @@ public class SFUsersEntity extends SFEntitiesBase
 	}
 
 	/**
+	 * Get List of User Shared Folders
+	 * Retrieve the list of shared folders the specified user has access to
+	 * @return A list of Folder objects, representing shared folders of an user
+	 */
+	public ISFQuery<SFODataFeed<SFItem>> getAllSharedFoldersForSpecificUser(URI url) throws InvalidOrMissingParameterException	{
+		if (url == null) {
+			throw new InvalidOrMissingParameterException("url");
+		}
+
+		SFApiQuery<SFODataFeed<SFItem>> sfApiQuery = new SFApiQuery<SFODataFeed<SFItem>>(this.client);
+		sfApiQuery.setFrom("Users");
+		sfApiQuery.setAction("AllSharedFolders");
+		sfApiQuery.addIds(url);
+		sfApiQuery.setHttpMethod("GET");
+		return sfApiQuery;
+	}
+
+	/**
 	* Get List of User Shared Folders
 	* Retrieve the top-level folders for this user. This method requires the account to be
 	* in the new UI model of "My Files", "Shared", "Connectors", "Favorites" tab - otherwise


### PR DESCRIPTION
This change will expose a new endpoint that was recently created in the API to allow a caller to request the list of Shared Folders for a specific user. The current functionality only allows for the Shared Folders of the currently authenticated user to be returned. This new call can only be made by a member of the Super User group within the Account.